### PR TITLE
Audio processing

### DIFF
--- a/src/main/python/audio.py
+++ b/src/main/python/audio.py
@@ -5,15 +5,19 @@ import matplotlib.pyplot as plt
 from matplotlib.pyplot import specgram
 import numpy as np
 
-def process(samples, f):    
+def process(samples, f):
+    """Process an audio clip and decide if it contains drone-like sound"""
+    # Take only the first channel in stereo audio
     if not isinstance(samples[0], np.int16):
         samples = samples[:,0]
+        
+    # Create spectrogram and band-pass filter
     specs, freqs, t, x = specgram(samples, NFFT=256, Fs=f)
     specs /= np.sum(specs)
-    
     summed = [sum(x) for x in specs]
     band = [abs(x-5680)<250 for x in freqs]
     
+    # Apply band-pass filter
     result = []
     score = 0
     for i in range(len(summed)):
@@ -23,6 +27,7 @@ def process(samples, f):
         else:
             result.append(0)
     
+    # Classify as drone if more than 0.7% of the sound is in then 5680 Hz range
     drone = score > 0.007
     print drone
     return drone


### PR DESCRIPTION
This PR adds a simple rule to classify audio as drone-containing or not. A spectrogram is calculated for every audio clip and its loudness is normalized. Audio clips are said to contain sound made by drones when 0.7% or more of the frequencies in the clips are in the range of 5680 Hz ± 250 Hz.